### PR TITLE
Fix zola config.toml

### DIFF
--- a/export_base_zola/config.toml
+++ b/export_base_zola/config.toml
@@ -7,15 +7,16 @@ description = "Example blog description"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = false
 
+generate_feed = true
+feed_filename = "rss.xml"
+feed_limit = 20
+
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
 
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
-
-generate_rss = true
-rss_limit = 20
 
 [extra]
 # Put all your custom variables here

--- a/export_base_zola/config.toml
+++ b/export_base_zola/config.toml
@@ -13,6 +13,7 @@ feed_limit = 20
 
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+[markdown]
 highlight_code = true
 
 # Whether to build a search index to be used later on by a JavaScript library

--- a/export_base_zola/index.html
+++ b/export_base_zola/index.html
@@ -31,7 +31,7 @@
 
         <footer>
             --
-            <br><a href="/rss.xml">RSS</a>
+            <br><a href="/{{config.feed_filename}}">RSS</a>
         </footer>
         {% endblock content %}
 


### PR DESCRIPTION
I couldn't use my rss feed when exporting my blog to Zola. This PR fixes this and also fixes the syntax highlighting.