### PR TITLE
Allow "preload" attribute

### DIFF
--- a/main/denylist.py
+++ b/main/denylist.py
@@ -158,6 +158,7 @@ ALLOWED_HTML_ATTRS = [
     "href",
     "id",
     "name",
+    "preload",
     "rel",
     "seamless",
     "span",


### PR DESCRIPTION
# Background

Basically, for [blog posts with heavy media content](https://bpev.mataroa.blog/blog/vx1-session-sweet-honey), it's a large load for a visitor to immediately download a lot of media.

The [preload](https://www.w3schools.com/TAgs/att_preload.asp) attribute lets us do things like:

- `<video preload="none" />`: don't load until the visitor presses play
- `<audio preload="metadata" />`: only load metadata, and load the actual audio media when the visitor presses play

I worked around this for the heaviest files by adding media via iframe, but this isn't really optimal for all the audio examples I have in these posts.

# Changes

- Adds "preload" attribute to the allow list.

NOTE: I didn't test this or clone to my computer or anything, and didn't look too hard at the repo, so I'm not sure if there are other requirements here.
