### PR TITLE
Prefer “free software” over “open source”

### DIFF
--- a/main/templates/main/landing.html
+++ b/main/templates/main/landing.html
@@ -55,7 +55,7 @@
             <li>Import text/markdown files</li>
             <li>Export as epub book format</li>
         </ul>
-        <li>100% <a href="https://github.com/mataroa-blog">open source</a></li>
+				<li>100% <a href="https://github.com/mataroa-blog">free software</a></li>
         <li><a href="{% url 'transparency' %}">Transparent</a> business sustainability</li>
     </ul>
 

--- a/main/templates/main/operandi.html
+++ b/main/templates/main/operandi.html
@@ -220,7 +220,7 @@
 
     <h2 id="open-source">Open Source</h2>
     <p>
-        We have a creed to write open source software. Mataroa is developed
+				We have a creed to write <a href="https://fsfe.org/freesoftware" title="Free Software explanation on FSFE website">free software</a>. Mataroa is developed
         publicly on <a href="https://sr.ht/~sirodoht/mataroa/sources">sr.ht</a>
         and <a href="https://github.com/mataroa-blog">GitHub</a>.
     </p>


### PR DESCRIPTION
Actually, Mataroa is 100% free software, and what the creator stands for is not merely open source, but Free Software. I replaced the words in the two occasions “open source” appeared.