### PR TITLE
fix rss feed on hugo export

### DIFF
--- a/export_base_hugo/baseof.html
+++ b/export_base_hugo/baseof.html
@@ -13,7 +13,9 @@
         {{- end }}
 
         <link href="{{ .Site.BaseURL }}style.css" rel="stylesheet">
-        <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml">
+        {{ with .OutputFormats.Get "rss" -}}
+            {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+        {{ end }}
     </head>
 
     <body>

--- a/export_base_hugo/config.toml
+++ b/export_base_hugo/config.toml
@@ -5,3 +5,8 @@ theme = "mataroa"
 
 [params]
     description = "Example blog description"
+
+[outputFormats]
+  [outputFormats.RSS]
+    mediatype = "application/rss"
+    baseName = "rss"

--- a/export_base_hugo/index.html
+++ b/export_base_hugo/index.html
@@ -23,7 +23,11 @@
 </main>
 
 <footer>
-    --
-    <br><a href="/rss.xml">RSS</a>
+    {{ with .OutputFormats.Get "rss" -}}
+        <p>
+            Subscribe via
+            {{ printf `<a href=%q title=%q>RSS</a>` .Permalink site.Title | safeHTML }}
+        </p>
+    {{ end }}
 </footer>
 {{ end }}

--- a/export_base_hugo/single.html
+++ b/export_base_hugo/single.html
@@ -20,6 +20,13 @@
     </article>
 </main>
 <footer>
-    <a href="/">← archive</a>
+    {{- with .Site.GetPage "/" }}
+        {{- with .OutputFormats.Get "rss" }}
+            <p>
+                Subscribe via
+                {{ printf `<a href=%q title=%q>RSS</a>` .Permalink site.Title | safeHTML }}
+            </p>
+        {{- end }}
+    {{- end }}
 </footer>
 {{ end }}


### PR DESCRIPTION
I tested this by exporting my blog and changing the theme locally.

- fixes the rss feed reference
- adds the "`Subscribe via RSS`" on the pages missing