### PR TITLE
add draft warning about post visibility

### DIFF
--- a/main/templates/main/post_detail.html
+++ b/main/templates/main/post_detail.html
@@ -25,6 +25,14 @@
             | <a href="{% url 'post_update' post.slug %}">Edit post</a>
             | <a href="{% url 'post_delete' post.slug %}">Del</a>
             {% endif %}
+
+            {% if post.is_draft %}
+            <blockquote>
+                <strong>
+                    ⚠️ This post is accessible to anyone with the link!
+                </strong>
+            </blockquote>
+            {%  endif %}
         </div>
 
         <div class="posts-item-body" itemprop="articleBody">


### PR DESCRIPTION
This introduces a small textual warning regarding draft visibility.

---

![image](https://github.com/user-attachments/assets/339afdb0-4281-4e6f-a1e3-f2351c53b9a7)
