### PR TITLE
Add anti-spam honeypot and timestamp check for comments

### DIFF
--- a/main/templates/main/comment_form.html
+++ b/main/templates/main/comment_form.html
@@ -57,6 +57,12 @@
             <textarea name="body" id="id_body" cols="60" rows="5">{{ form.body.value|default_if_none:'' }}</textarea>
         </p>
 
+        {# Anti-spam honeypot: hidden from humans, filled by bots. #}
+        <p style="position:absolute;left:-9999px" aria-hidden="true">
+            <input type="text" name="url" tabindex="-1" autocomplete="off" value="">
+        </p>
+        <input type="hidden" name="ts" value="{{ comment_ts }}">
+
         {% csrf_token %}
         <input type="submit" value="Publish comment">
     </form>

--- a/main/templates/main/post_detail.html
+++ b/main/templates/main/post_detail.html
@@ -101,6 +101,12 @@
                 <textarea name="body" id="id_body" cols="60" rows="5"></textarea>
             </p>
 
+            {# Anti-spam honeypot: hidden from humans, filled by bots. #}
+            <p style="position:absolute;left:-9999px" aria-hidden="true">
+                <input type="text" name="url" tabindex="-1" autocomplete="off" value="">
+            </p>
+            <input type="hidden" name="ts" value="{{ comment_ts }}">
+
             {% csrf_token %}
             <input type="submit" value="Publish comment">
         </form>

--- a/main/tests/test_comments.py
+++ b/main/tests/test_comments.py
@@ -1,8 +1,16 @@
+import time
+
 from django.conf import settings
+from django.core import signing
 from django.test import TestCase
 from django.urls import reverse
 
 from main import models
+
+
+def _signed_ts(seconds_ago=10):
+    """Signed timestamp matching what PostDetail renders into the comment form."""
+    return signing.dumps(int(time.time()) - seconds_ago)
 
 
 class CommentCreateAuthorTestCase(TestCase):
@@ -54,6 +62,7 @@ class CommentCreateTestCase(TestCase):
             "name": "Jon",
             "email": "jon@wick.com",
             "body": "Content sentence.",
+            "ts": _signed_ts(),
         }
         response = self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -141,6 +150,7 @@ class CommentNameCreateTestCase(TestCase):
         data = {
             "name": "Jon",
             "body": "Content sentence.",
+            "ts": _signed_ts(),
         }
         response = self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -167,6 +177,7 @@ class CommentEmailCreateTestCase(TestCase):
         data = {
             "email": "jon@wick.com",
             "body": "Content sentence.",
+            "ts": _signed_ts(),
         }
         response = self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -193,6 +204,7 @@ class CommentNoAuthCreateTestCase(TestCase):
     def test_comment_create(self):
         data = {
             "body": "Content sentence.",
+            "ts": _signed_ts(),
         }
         response = self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -226,6 +238,60 @@ class CommentNoBodyCreateTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(models.Comment.objects.all().count(), 0)
+
+
+class CommentSpamFilterTestCase(TestCase):
+    def setUp(self):
+        self.user = models.User.objects.create(username="alice", comments_on=True)
+        self.post = models.Post.objects.create(
+            title="Hello world",
+            slug="hello-world",
+            owner=self.user,
+        )
+
+    def _post(self, **extra):
+        data = {"body": "Content sentence.", "ts": _signed_ts(), **extra}
+        return self.client.post(
+            reverse("comment_create", args=(self.post.slug,)),
+            HTTP_HOST="alice." + settings.CANONICAL_HOST,
+            data=data,
+        )
+
+    def test_honeypot_filled_is_dropped(self):
+        response = self._post(url="http://spam.example/")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.Comment.objects.count(), 0)
+
+    def test_missing_ts_is_dropped(self):
+        response = self._post(ts="")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.Comment.objects.count(), 0)
+
+    def test_invalid_ts_is_dropped(self):
+        response = self._post(ts="not-a-valid-signed-value")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.Comment.objects.count(), 0)
+
+    def test_ts_too_recent_is_dropped(self):
+        response = self._post(ts=_signed_ts(seconds_ago=0))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.Comment.objects.count(), 0)
+
+    def test_valid_ts_and_empty_honeypot_is_saved(self):
+        response = self._post(url="")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.Comment.objects.count(), 1)
+
+    def test_form_rerender_after_validation_error_keeps_ts(self):
+        # Empty body -> form re-renders. The re-rendered page must include
+        # a fresh signed ts so the user's next submission isn't dropped.
+        response = self.client.post(
+            reverse("comment_create", args=(self.post.slug,)),
+            HTTP_HOST="alice." + settings.CANONICAL_HOST,
+            data={"body": "", "ts": _signed_ts()},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="ts" value=""')
 
 
 class CommentDisallowedCreateTestCase(TestCase):
@@ -338,6 +404,7 @@ class CommentsApproveTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -380,6 +447,7 @@ class CommentsApproveNoAuthTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -421,6 +489,7 @@ class CommentsApproveNonOwnerTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -464,6 +533,7 @@ class CommentsDeleteTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -501,6 +571,7 @@ class CommentsDeleteNoAuthTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),
@@ -537,6 +608,7 @@ class CommentsDeleteNonOwnerTestCase(TestCase):
         )
         data = {
             "body": "Hey, I am a comment.",
+            "ts": _signed_ts(),
         }
         self.client.post(
             reverse("comment_create", args=(self.post.slug,)),

--- a/main/views/general.py
+++ b/main/views/general.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -13,7 +14,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LogoutView as DjLogoutView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sitemaps.views import sitemap as DjSitemapView
-from django.core import mail
+from django.core import mail, signing
 from django.core.exceptions import PermissionDenied, TooManyFilesSent
 from django.db.models import Count, Sum
 from django.db.models.functions import Length, TruncDay
@@ -332,6 +333,8 @@ class PostDetail(DetailView):
             context["comments_pending"] = models.Comment.objects.filter(
                 post=self.object, is_approved=False
             )
+            # Signed timestamp for the anti-spam time trap in CommentCreate.
+            context["comment_ts"] = signing.dumps(int(time.time()))
 
         # do not record analytic if post is authed user's
         if (
@@ -582,6 +585,10 @@ class CommentCreate(SuccessMessageMixin, CreateView):
         context["post"] = models.Post.objects.get(
             owner__username=self.request.subdomain, slug=self.kwargs["slug"]
         )
+        # Signed timestamp for the anti-spam time trap. Must be present on
+        # form re-renders too (e.g. validation errors), or the user's next
+        # submission will be silently dropped as spam.
+        context["comment_ts"] = signing.dumps(int(time.time()))
         return context
 
     def get_success_url(self):
@@ -592,6 +599,16 @@ class CommentCreate(SuccessMessageMixin, CreateView):
         if not models.User.objects.get(username=self.request.subdomain).comments_on:
             form.add_error(None, "No comments allowed on this blog.")
             return self.render_to_response(self.get_context_data(form=form))
+
+        # Anti-spam. Honeypot: the "url" field is hidden from humans, so a
+        # filled value means a bot. Time trap: bots POST directly without
+        # loading the form first (missing/invalid ts) or submit within
+        # milliseconds of loading (humans take longer to write a comment).
+        if self._looks_like_spam():
+            messages.success(self.request, self.success_message)
+            return HttpResponseRedirect(
+                reverse("post_detail", args=(self.kwargs["slug"],))
+            )
 
         # save comment as not approved
         self.object = form.save(commit=False)
@@ -626,6 +643,20 @@ class CommentCreate(SuccessMessageMixin, CreateView):
         )
 
         return super().form_valid(form)
+
+    def _looks_like_spam(self):
+        if self.request.POST.get("url"):
+            logger.info("Comment dropped: honeypot filled")
+            return True
+        try:
+            ts = signing.loads(self.request.POST.get("ts", ""), max_age=86400)
+        except signing.BadSignature:
+            logger.info("Comment dropped: missing or invalid ts")
+            return True
+        if time.time() - ts < 3:
+            logger.info("Comment dropped: submitted too fast")
+            return True
+        return False
 
     def dispatch(self, request, *args, **kwargs):
         if hasattr(request, "subdomain") and request.method == "POST":


### PR DESCRIPTION
This adds a url field and a timestamp field to the comment input form. The URL field is rendered way off screen. The timestamp is how long the user spends on filling in the comment form. If the URL field is populated, or the timestamp field is something weird (such as less than 3 seconds), the comment is silently dropped.

Coded with AI help, read thru and edited by hand.

It adds test cases to verify and clarify exactly how it behaves.