### PR TITLE
Add signup setting

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -7,6 +7,7 @@ export DEBUG=1
 # 1: stop and off
 # 0: do not stop and on
 export LOCALDEV=1
+export SIGNUPS_ENABLED=1
 
 # Admin email for receiving server errors
 export ADMIN_EMAIL=

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ file one can copy as base:
 cp .envrc.example .envrc
 ```
 
+Set `SIGNUPS_ENABLED=0` to close both signup steps. Signups are enabled by
+default.
+
 When on Docker, to change or populate environment variables, edit the `environment`
 key of the `web` service either directly on `docker-compose.yml` or by overriding it
 using the standard named git-ignored `docker-compose.override.yml`.

--- a/main/templates/main/user_create_disabled.html
+++ b/main/templates/main/user_create_disabled.html
@@ -1,0 +1,15 @@
+{% extends 'main/layout.html' %}
+
+{% block title %}Sign up{% endblock %}
+
+{% block head_viewport %}
+<meta name="viewport" content="width=device-width, user-scalable=no">
+{% endblock head_viewport %}
+
+{% block content %}
+<main>
+    <h1>Registrations are closed</h1>
+
+    <p>New registrations are not available right now.</p>
+</main>
+{% endblock content %}

--- a/main/tests/test_users.py
+++ b/main/tests/test_users.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from main import models, scheme
@@ -11,16 +11,25 @@ class IndexTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(SIGNUPS_ENABLED=False)
 class UserCreateDisabledTestCase(TestCase):
-    def test_user_creation(self):
+    def test_first_step(self):
+        response = self.client.post(reverse("user_create"))
+        self.assertContains(response, "Registrations are closed")
+        self.assertFalse(models.Onboard.objects.exists())
+
+    def test_second_step(self):
+        onboard = models.Onboard.objects.create()
         data = {
             "username": "alice",
             "password1": "abcdef123456",
             "password2": "abcdef123456",
             "blog_title": "New blog",
         }
-        response = self.client.post(reverse("user_create"), data)
-        self.assertEqual(response.status_code, 302)
+        response = self.client.post(
+            reverse("user_create_step_two", args=(onboard.code,)), data
+        )
+        self.assertContains(response, "Registrations are closed")
         self.assertFalse(models.User.objects.filter(username=data["username"]).exists())
 
 

--- a/main/views/general.py
+++ b/main/views/general.py
@@ -171,6 +171,11 @@ class UserCreateStepOne(CreateView):
     form_class = forms.OnboardForm
     template_name = "main/user_create_step_one.html"
 
+    def dispatch(self, request, *args, **kwargs):
+        if not settings.SIGNUPS_ENABLED:
+            return render(request, "main/user_create_disabled.html")
+        return super().dispatch(request, *args, **kwargs)
+
     def form_valid(self, form):
         self.object = form.save()
         return redirect("user_create_step_two", onboard_code=self.object.code)
@@ -203,6 +208,8 @@ class UserCreateStepTwo(CreateView):
         return HttpResponseRedirect(self.get_success_url())
 
     def dispatch(self, request, *args, **kwargs):
+        if not settings.SIGNUPS_ENABLED:
+            return render(request, "main/user_create_disabled.html")
         self.onboard = get_object_or_404(
             models.Onboard,
             code=kwargs["onboard_code"],

--- a/mataroa/settings.py
+++ b/mataroa/settings.py
@@ -28,6 +28,7 @@ SECRET_KEY = os.getenv("SECRET_KEY", "nonrandom_secret")
 DEBUG = os.getenv("DEBUG") == "1"
 
 LOCALDEV = os.getenv("LOCALDEV") == "1"
+SIGNUPS_ENABLED = os.getenv("SIGNUPS_ENABLED", "1") == "1"
 
 ALLOWED_HOSTS = [
     "127.0.0.1",


### PR DESCRIPTION
Adds `SIGNUPS_ENABLED` for closing both signup steps without code changes. Includes a closed-registration page and tests for both routes.

Closes #76.
